### PR TITLE
Find li.active items inside datalist only, instead of whole document.

### DIFF
--- a/js/jquery.relevant-dropdown.js
+++ b/js/jquery.relevant-dropdown.js
@@ -106,7 +106,7 @@
       // Watch arrow keys for up and down
       $input.on("keydown", function(e) {	
 
-        var active = $("li.active"),
+        var active = $datalist.find("li.active"),
             datalistHeight = $datalist.outerHeight(),
             datalistItemsHeight = datalistItems.outerHeight();
 


### PR DESCRIPTION
Because of this bug, the plugin doesn't work with Twitter Bootstrap
