### PR TITLE
Append List to Input Parent Instead of Body

### DIFF
--- a/js/jquery.relevant-dropdown.js
+++ b/js/jquery.relevant-dropdown.js
@@ -16,7 +16,6 @@
     }, options);
 
     return this.each(function() {
-
       var $input = $(this),
           list_id = $input.attr('list'),
           $datalist = $("#" + list_id),
@@ -35,14 +34,14 @@
           $("<ul />", {
             "class": "datalist",
             "id"   : list_id
-          }).appendTo("body");
-    
+          }).appendTo($input.parent());
+
           // Remove old datalist
           $datalist.remove();
-    
+
           // Update pointer
           $datalist = $("#" + list_id);
-    
+
           // Fill new fake datalist
           datalistItems.each(function() {
             temp_item = $("<li />", {
@@ -74,6 +73,7 @@
         })
         .on("keyup focus", function(e) {
           searchPosition = $input.position();
+
           // Build datalist
           $datalist
             .show()


### PR DESCRIPTION
I know this is an old repo but it's still relevant since Safari won't support `datalist` anytime soon. 

I ran into an issue where the list is appended to body which may work fine in the isolation of an example page but in the real world it could be very far from the `$input` element DOM-wise. Furthermore, [jQuery.position](https://api.jquery.com/position/) gets the position of the element _relative to the parent_, not the viewport. That means appending to body doesn't work because the coordinates are for it's position inside the `$input` parent.

The fix I chose is to append to the parent and keep the position code intact because it works great this way rather than keep appending it to body and mess with coordinates relative to the viewport which can be problematic.

Appending to `body`:
<img width="564" alt="silversheet___medical_credentialing_made_easy" src="https://cloud.githubusercontent.com/assets/387930/19405516/15b5ce1e-922d-11e6-9416-e856fd013d0e.png">

Appending to `$input.parent()`:
<img width="572" alt="silversheet___medical_credentialing_made_easy" src="https://cloud.githubusercontent.com/assets/387930/19405585/13bd3dda-922e-11e6-8f03-cea5fd0b27bc.png">


(Sorry about the whitespace cleanup, Atom does it.)